### PR TITLE
chore: run Dependabot weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,9 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "cron"
-      cronjob: "0 13 * * *"
+      interval: "weekly"
+      day: "wednesday"
+      time: "13:00"
       timezone: "America/Chicago"
     open-pull-requests-limit: 2
     groups:
@@ -22,8 +23,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "cron"
-      cronjob: "0 13 * * *"
+      interval: "weekly"
+      day: "wednesday"
+      time: "13:00"
       timezone: "America/Chicago"
     open-pull-requests-limit: 2
     groups:


### PR DESCRIPTION
## Summary

- change Dependabot version-update checks to weekly
- run them on wednesday at 13:00 America/Chicago
- preserve existing ecosystems, grouping, limits, ignores, and cooldowns

Security updates remain alert-triggered and are not delayed by this version-update schedule.