### PR TITLE
docs: add thin pstack-compliance process to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,14 +40,14 @@ This repository hosts `r2`, a Go (1.24) CLI and library for Cloudflare R2 built 
 
 ## Process
 
-This is a CLI, not the Erdos product. Keep the loop thinner than the monorepo. This **Process** section is canonical for Cursor, Claude Code, and Codex — do not put a fork only under `.cursor/`. `CLAUDE.md` points here; there is no `.codex/` tree.
+This is a CLI, not the Erdos product. Keep the loop thinner than the monorepo. Every coding agent, in any harness, reads this file. Do not add per-tool copies or forks.
 
 ### Merge-ready
 
-- **Will eyes:** CI green, no open Greptile/Codex threads, base clean.
+- **Human eyes:** CI green, no open bot review threads, base clean.
 - Rebase or conflict-resolve on the existing branch. Never leave **Update branch** as a human click. Do not open a superseding PR for Dependabot or in-flight fixes.
-- Wait for Greptile and Codex on one SHA, then one remediation push, then one reconfirm. Do not push-per-comment.
-- Erdos-org Dependabot is Will-merge: report ready, do not merge yourself. Greptile 5/5 when it reviewed; "no reviewable files" counts as clear. Socket unsafe = hold.
+- Wait for every participating review bot to finish on one SHA, then one remediation push, then one reconfirm. A bot that never started is not participating. Do not push-per-comment.
+- Erdos-org Dependabot is human-merge (agents do not merge): report ready. Greptile 5/5 when it reviewed; "no reviewable files" counts as clear. Socket unsafe = hold.
 
 ### Verify
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,28 @@ This repository hosts `r2`, a Go (1.24) CLI and library for Cloudflare R2 built 
 ## Commit & Pull Request Guidelines
 - Commits: follow Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`), as in this repo’s history.
 - PRs must include: clear description, linked issue, CLI examples (e.g., `r2 cp r2://bucket/a b`), and doc updates when UX changes.
-- Checks: ensure `go fmt`, `go vet`, `go test`, and `go mod tidy` pass; avoid diff in `go.sum` unless necessary.
+- Checks: ensure `go fmt`, `go vet`, `go test`, and `go mod tidy` pass; avoid diff in `go.sum` unless necessary. Agent-loop and merge-ready policy: **Process**.
 
 ## Security & Configuration Tips
 - Never commit credentials; `r2 configure` stores profiles in `~/.r2`.
 - Redact secrets in logs/output; validate bucket names and paths (see `pkg/helpers.go`).
+
+## Process
+
+This is a CLI, not the Erdos product. Keep the loop thinner than the monorepo.
+
+### Merge-ready
+
+- **Will eyes:** CI green, no open Greptile/Codex threads, base clean.
+- Rebase or conflict-resolve on the existing branch. Never leave **Update branch** as a human click. Do not open a superseding PR for Dependabot or in-flight fixes.
+- Wait for Greptile and Codex on one SHA, then one remediation push, then one reconfirm. Do not push-per-comment.
+- Erdos-org Dependabot is Will-merge: report ready, do not merge yourself. Greptile 5/5 when it reviewed; "no reviewable files" counts as clear. Socket unsafe = hold.
+
+### Verify
+
+Named path (same check set as above): `go fmt ./... && go vet ./... && go test ./...`. Unit tests must not make live R2 calls. If a change touches real R2 behavior, name an integration or dry-run note on the PR; unit mocks are not enough.
+
+### Sequence
+
+- Prefer small PRs. Open mega work as draft and split before ready-for-review.
+- Loop budget: style/test P2 remediations ≤2, then stop. Security and lockfile issues always get fixed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ This repository hosts `r2`, a Go (1.24) CLI and library for Cloudflare R2 built 
 
 ## Process
 
-This is a CLI, not the Erdos product. Keep the loop thinner than the monorepo.
+This is a CLI, not the Erdos product. Keep the loop thinner than the monorepo. This **Process** section is canonical for Cursor, Claude Code, and Codex — do not put a fork only under `.cursor/`. `CLAUDE.md` points here; there is no `.codex/` tree.
 
 ### Merge-ready
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,9 +51,9 @@ This is a CLI, not the Erdos product. Keep the loop thinner than the monorepo. T
 
 ### Verify
 
-Named path (same check set as above): `go fmt ./... && go vet ./... && go test ./...`. Unit tests must not make live R2 calls. If a change touches real R2 behavior, name an integration or dry-run note on the PR; unit mocks are not enough.
+Named path (the Checks set above): `go fmt ./... && go vet ./... && go test ./...`, then `go mod tidy` with no `go.mod`/`go.sum` drift. Unit tests must not make live R2 calls. If a change touches real R2 behavior, name an integration or dry-run note on the PR; unit mocks are not enough.
 
 ### Sequence
 
 - Prefer small PRs. Open mega work as draft and split before ready-for-review.
-- Loop budget: style/test P2 remediations ≤2, then stop. Security and lockfile issues always get fixed.
+- Loop budget: at most two batched review rounds for style/test P2s (wait → one push → one reconfirm is one round). Then stop; leave remaining P2 threads open and report not-ready with a named follow-up. Security and lockfile issues always get fixed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ R2 is a CLI and Go library for working with Cloudflare's R2 Storage service. It 
 
 ## Process
 
-Process, merge-ready, and verify rules live in [`AGENTS.md`](AGENTS.md) (**Process**). Do not fork a second dialect here.
+Process, merge-ready, and verify rules live in [`AGENTS.md`](AGENTS.md) (**Process**).
 
 ## Development Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 R2 is a CLI and Go library for working with Cloudflare's R2 Storage service. It implements AWS S3-compatible commands to provide simple-to-use features similar to the AWS CLI's s3 subcommand. The project is written in Go and uses the Cobra framework for CLI commands.
 
+## Process
+
+Process, merge-ready, and verify rules live in [`AGENTS.md`](AGENTS.md) (**Process**). Do not fork a second dialect here.
+
 ## Development Commands
 
 ### Building the Project


### PR DESCRIPTION
Adds a short **Process** section to `AGENTS.md` so every coding agent, in any harness, follows the same merge-ready and verify rules. This is a CLI, not the Erdos product, so the section is thinner than the monorepo.

The existing Go contributor guide is unchanged aside from a **Process** pointer on the Checks bullet. `CLAUDE.md` points at `AGENTS.md` for process, merge-ready, and verify.

### What landed

- **Merge-ready:** CI green, no open bot review threads, base clean. Rebase or conflict-resolve on the existing branch; never leave **Update branch** as a human click; no superseding PRs for Dependabot or in-flight fixes.
- **Review loop:** wait for every participating review bot to finish on one SHA, then one remediation push, then one reconfirm. A bot that never started is not participating.
- **Dependabot (Erdos org):** human-merge (agents do not merge) — report ready. Greptile 5/5 when it reviewed; "no reviewable files" counts as clear. Socket unsafe = hold.
- **Named verify path:** `go fmt ./... && go vet ./... && go test ./...`, then `go mod tidy` with no `go.mod`/`go.sum` drift. Live R2 stays out of unit tests; real R2 behavior needs a named integration/dry-run note.
- **Sequence:** small PRs; mega work opens draft. Style/test P2 budget is two batched review rounds, then stop and report not-ready; security/lockfile always fix.

### Fable batch

On this branch (`f90c6d5`): no harness vendor names in Process; participating-bot wait; human-merge language.

### CLI examples

Docs-only; no command UX change. Existing usage is unchanged (`r2 cp r2://bucket/a b`, `r2 ls`, `r2 sync`).

### Verification

Named path (docs-only): `go fmt ./... && go vet ./... && go test ./...`, then `go mod tidy` with no drift.

Human merge after review.